### PR TITLE
Add helper tests

### DIFF
--- a/ccp-ui/src/lib.test.mjs
+++ b/ccp-ui/src/lib.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import { spacesToCamel, valueToOption, genLogger } from './lib.js';
+
+assert.equal(spacesToCamel('call disposition'), 'callDisposition');
+assert.equal(spacesToCamel('Hello World'), 'helloWorld');
+assert.deepStrictEqual(valueToOption('A'), { value: 'A', label: 'A' });
+
+let calledArgs = null;
+const origLog = console.log;
+console.log = (...args) => {
+  calledArgs = args;
+};
+const logger = genLogger('test');
+logger.log('message');
+console.log = origLog;
+assert.deepStrictEqual(calledArgs, ['test', '-', 'message']);
+
+console.log('All tests passed');


### PR DESCRIPTION
## Summary
- add a minimal Node-based test for helper utilities

## Testing
- `node ccp-ui/src/lib.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_684352e899888323b68327fdc8055236